### PR TITLE
fix: Remove Handler from Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -70,13 +70,6 @@ body:
       placeholder: "Chrome 96.0.4664.110"
     validations:
       required: true
-  - type: input
-    attributes:
-      label: Handler
-      description: List what intergration you are using
-      placeholder: "phpvms5"
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Additional context


### PR DESCRIPTION
The handler field is not needed anymore because this is the phpVMS 7 module api.