### PR TITLE
fix: Position Report ID Conflicts

### DIFF
--- a/Http/Controllers/Api/FlightsController.php
+++ b/Http/Controllers/Api/FlightsController.php
@@ -33,6 +33,7 @@ use GuzzleHttp\Client;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Modules\SmartCARS3phpVMS7Api\Actions\PirepDistanceCalculation;
 use Modules\SmartCARS3phpVMS7Api\Jobs\CalculatePirepDistance;
 use Modules\SmartCARS3phpVMS7Api\Models\ActiveFlight;
@@ -504,6 +505,7 @@ class FlightsController extends Controller
         }
         $pirep->save();
         $pirep->acars()->create([
+            'id'       => Str::orderedUuid(),
             'status'   => $pirep->status,
             'type'     => AcarsType::FLIGHT_PATH,
             'lat'      => $input['latitude'],


### PR DESCRIPTION
The stock UUID generation within phpVMS is not working as expected, which has caused a few position reports on some flights to be lost.

This fix was suggested by Nabeel, the creator of phpVMS, to avoid these position conflicts.