### PR TITLE
fix: correct namespace casing in middleware files

### DIFF
--- a/Http/Middleware/SCAuth.php
+++ b/Http/Middleware/SCAuth.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Log;
 
 /**
  * Class SCAuth
- * @package Modules\SmartCARSvms7\Http\Middleware
+ * @package Modules\SmartCARS3phpVMS7Api\Http\Middleware
  */
 class SCAuth
 {

--- a/Http/Middleware/SCAuth.php
+++ b/Http/Middleware/SCAuth.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\SmartcARS3phpVMS7Api\Http\Middleware;
+namespace Modules\SmartCARS3phpVMS7Api\Http\Middleware;
 
 use App\Models\User;
 use Closure;

--- a/Http/Middleware/SCHeaders.php
+++ b/Http/Middleware/SCHeaders.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\SmartcARS3phpVMS7Api\Http\Middleware;
+namespace Modules\SmartCARS3phpVMS7Api\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;

--- a/Http/Middleware/SCHeaders.php
+++ b/Http/Middleware/SCHeaders.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 
 /**
  * Class SCAuth
- * @package Modules\SmartCARSvms7\Http\Middleware
+ * @package Modules\SmartCARS3phpVMS7Api\Http\Middleware
  */
 class SCHeaders
 {


### PR DESCRIPTION
This PR fixes some naming inconsistencies that can cause server errors on case-sensitive systems like Linux or MacOS.

For example when running phpVMS with this smartCARS 3 module on a Linux system when I requested an API route I got the error:

```json
{"type":"https:\/\/phpvms.net\/errors\/internal-error","title":"Target class [Modules\\SmartCARS3phpVMS7Api\\Http\\Middleware\\SCHeaders] does not exist.","details":"Target class [Modules\\SmartCARS3phpVMS7Api\\Http\\Middleware\\SCHeaders] does not exist.","status":503,"error":{"status":503,"message":"Target class [Modules\\SmartCARS3phpVMS7Api\\Http\\Middleware\\SCHeaders] does not exist."},"original_exception":"Illuminate\\Contracts\\Container\\BindingResolutionException"}
```

This occurs becuase the module folder is caled `SmartCARS3phpVMS7Api` but in the code `SmartcARS3phpVMS7Api` (with a lowercase `c` is used).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected namespace declarations and documentation annotations for middleware components to ensure consistency and proper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->